### PR TITLE
Promote develop → staging

### DIFF
--- a/.changeset/migrate-products-table-datatable.md
+++ b/.changeset/migrate-products-table-datatable.md
@@ -1,0 +1,5 @@
+---
+"@coongro/products": minor
+---
+
+Migrate ProductsTable to DataTable with mobile card view (mobileRender)

--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -185,10 +185,11 @@ export function ProductForm(props: ProductFormProps) {
   const showCategory = !hiddenSet.has('category_id');
   const showIsActive = !hiddenSet.has('is_active');
 
-  function renderSectionHeader(title: string) {
+  function renderSectionHeader(title: string, icon: string) {
     return React.createElement(
       'h3',
-      { className: 'text-sm font-medium text-cg-text-muted uppercase tracking-wider' },
+      { className: 'flex items-center gap-2 text-sm font-medium text-cg-text-muted' },
+      React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
       title
     );
   }
@@ -211,7 +212,7 @@ export function ProductForm(props: ProductFormProps) {
 
   // --- Sección: Información básica ---
   if (visibleBasic.length > 0 || showCategory) {
-    const sectionItems: React.ReactNode[] = [renderSectionHeader('Información básica')];
+    const sectionItems: React.ReactNode[] = [renderSectionHeader('Información básica', 'Package')];
     visibleBasic.forEach((field) => {
       sectionItems.push(renderField(field, formData[field.key], handleChange));
     });
@@ -237,7 +238,7 @@ export function ProductForm(props: ProductFormProps) {
 
   // --- Sección: Precios ---
   if (visiblePricing.length > 0) {
-    const sectionItems: React.ReactNode[] = [renderSectionHeader('Precios')];
+    const sectionItems: React.ReactNode[] = [renderSectionHeader('Precios', 'DollarSign')];
     visiblePricing.forEach((field) => {
       sectionItems.push(renderField(field, formData[field.key], handleChange));
     });
@@ -252,7 +253,7 @@ export function ProductForm(props: ProductFormProps) {
 
   // --- Sección: Inventario ---
   if (visibleInventory.length > 0) {
-    const sectionItems: React.ReactNode[] = [renderSectionHeader('Inventario')];
+    const sectionItems: React.ReactNode[] = [renderSectionHeader('Inventario', 'Warehouse')];
     visibleInventory.forEach((field) => {
       sectionItems.push(renderField(field, formData[field.key], handleChange));
     });

--- a/src/components/ProductsTable.tsx
+++ b/src/components/ProductsTable.tsx
@@ -1,278 +1,182 @@
+/**
+ * Tabla de productos con búsqueda, sort y paginación.
+ * Usa DataTable de ui-components para renderizado desktop + cards en móvil.
+ */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useProducts } from '../hooks/useProducts.js';
-import type { ProductsTableProps, ColumnDef } from '../types/components.js';
+import type { ProductsTableProps } from '../types/components.js';
 import type { Product } from '../types/domain.js';
 
 import { StockBadge } from './StockBadge.js';
 
 const React = getHostReact();
-const { useState, useCallback, useMemo, useEffect } = React;
+const UI = getHostUI();
+const { useState, useCallback, useMemo } = React;
 
-type SortDir = 'asc' | 'desc' | null;
-
-const DEFAULT_COLUMNS: ColumnDef<Product>[] = [
-  { key: 'name', header: 'Nombre', sortable: true },
-  { key: 'sku', header: 'SKU', render: (p) => p.sku ?? '—' },
-  {
-    key: 'sale_price',
-    header: 'Precio',
-    sortable: true,
-    render: (p) => (p.sale_price ? `$${Number(p.sale_price).toFixed(2)}` : '—'),
-  },
-  {
-    key: 'stock',
-    header: 'Stock',
-    sortable: true,
-    render: (p) =>
-      React.createElement(StockBadge, {
-        stock: p.stock_current,
-        minimum: p.stock_minimum,
-      }),
-  },
-  {
-    key: 'is_active',
-    header: 'Estado',
-    render: (p) => {
-      const UI = getHostUI();
-      return React.createElement(
-        UI.Badge,
-        { variant: p.is_active ? 'success' : 'secondary', size: 'sm' },
-        p.is_active ? 'Activo' : 'Inactivo'
-      );
-    },
-  },
-];
+const SORTABLE_KEYS = new Set(['name', 'sale_price', 'stock']);
 
 export function ProductsTable(props: ProductsTableProps) {
   const {
-    columns,
+    columns: customColumns,
     extraColumns = [],
     extraActions = [],
-    extraFilters: _extraFilters = [],
     selectable = false,
     emptyMessage = 'No se encontraron productos',
     onRowClick,
     filters: initialFilters,
   } = props;
 
-  const UI = getHostUI();
   const { data, loading, error, setFilters, pagination, refetch } = useProducts({
     initialFilters,
     pageSize: 25,
   });
 
   const [searchValue, setSearchValue] = useState('');
-  const debouncedSearch = UI.useDebounce(searchValue, 300);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [sortBy, setSortBy] = useState<string | null>(initialFilters?.orderBy ?? null);
-  const [sortDir, setSortDir] = useState<SortDir>(initialFilters?.orderDir ?? null);
+  const [sortKey, setSortKey] = useState<string>(initialFilters?.orderBy ?? '');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc' | null>(initialFilters?.orderDir ?? null);
 
-  // Aplicar filtro de búsqueda solo cuando el valor debounceado cambie
-  useEffect(() => {
-    setFilters({ query: debouncedSearch || undefined });
-  }, [debouncedSearch, setFilters]);
+  const handleSearch = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+      setFilters({ query: value || undefined });
+    },
+    [setFilters]
+  );
 
   const handleSort = useCallback(
-    (key: string) => {
-      let nextDir: SortDir;
-      if (sortBy !== key) {
-        nextDir = 'asc';
-      } else if (sortDir === 'asc') {
-        nextDir = 'desc';
-      } else {
-        nextDir = null;
-      }
-
-      const nextKey = nextDir ? key : null;
-      setSortBy(nextKey);
-      setSortDir(nextDir);
+    (key: string, direction: 'asc' | 'desc' | null) => {
+      if (!SORTABLE_KEYS.has(key)) return;
+      setSortKey(direction ? key : '');
+      setSortDir(direction);
       setFilters({
-        orderBy: nextKey ?? undefined,
-        orderDir: nextDir ?? undefined,
+        orderBy: direction ? key : undefined,
+        orderDir: direction ?? undefined,
       });
     },
-    [sortBy, sortDir, setFilters]
+    [setFilters]
   );
 
-  const allColumns = useMemo(
-    () => [...(columns ?? DEFAULT_COLUMNS), ...extraColumns],
-    [columns, extraColumns]
-  );
-
-  const handleSearch = useCallback((e: { target: { value: string } }) => {
-    setSearchValue(e.target.value);
-  }, []);
-
-  const toggleSelect = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
-
-  // Loading
-  if (loading && data.length === 0) {
-    return React.createElement(UI.LoadingOverlay, {
-      variant: 'skeleton',
-      rows: 6,
-      inline: true,
-    });
-  }
-
-  // Error
-  if (error) {
-    return React.createElement(UI.ErrorDisplay, {
-      title: 'Error al cargar productos',
-      message: error,
-      onRetry: () => void refetch(),
-    });
-  }
-
-  // Mapear sortDirection para TableHead
-  function getSortDirection(col: ColumnDef<Product>) {
-    if (!col.sortable) return undefined; // no sortable
-    if (sortBy !== col.key) return false as const; // sortable sin dir
-    return sortDir === 'asc'
-      ? ('asc' as const)
-      : sortDir === 'desc'
-        ? ('desc' as const)
-        : (false as const);
-  }
-
-  return React.createElement(
-    'div',
-    { className: 'flex flex-col gap-4' },
-
-    // Search bar
-    React.createElement(UI.Input, {
-      type: 'text',
-      value: searchValue,
-      onChange: handleSearch,
-      placeholder: 'Buscar productos...',
-    }),
-
-    // Table
-    data.length === 0
-      ? React.createElement(UI.EmptyState, { title: emptyMessage })
-      : React.createElement(
-          UI.Table,
-          null,
-
-          // Head
+  const dtColumns = useMemo(() => {
+    const base = customColumns ?? [
+      { key: 'name', header: 'Nombre', sortable: true },
+      { key: 'sku', header: 'SKU', render: (p: Product) => p.sku ?? '—' },
+      {
+        key: 'sale_price',
+        header: 'Precio',
+        sortable: true,
+        render: (p: Product) => (p.sale_price ? `$${Number(p.sale_price).toFixed(2)}` : '—'),
+      },
+      {
+        key: 'stock',
+        header: 'Stock',
+        sortable: true,
+        render: (p: Product) =>
+          React.createElement(StockBadge, {
+            stock: p.stock_current,
+            minimum: p.stock_minimum,
+          }),
+      },
+      {
+        key: 'is_active',
+        header: 'Estado',
+        render: (p: Product) =>
           React.createElement(
-            UI.TableHeader,
-            null,
-            React.createElement(
-              UI.TableRow,
-              null,
-              selectable && React.createElement(UI.TableHead, { className: 'w-10' }),
-              allColumns.map((col) =>
-                React.createElement(
-                  UI.TableHead,
-                  {
-                    key: col.key,
-                    sortDirection: getSortDirection(col),
-                    onSort: col.sortable ? () => handleSort(col.key) : undefined,
-                  },
-                  col.header
-                )
-              ),
-              extraActions.length > 0 &&
-                React.createElement(UI.TableHead, { className: 'text-right' }, 'Acciones')
-            )
+            UI.Badge,
+            { variant: p.is_active ? 'success' : 'secondary', size: 'sm' },
+            p.is_active ? 'Activo' : 'Inactivo'
           ),
+      },
+    ];
 
-          // Body
-          React.createElement(
-            UI.TableBody,
-            null,
-            data.map((product) =>
-              React.createElement(
-                UI.TableRow,
-                {
-                  key: product.id,
-                  onClick: onRowClick ? () => onRowClick(product) : undefined,
-                  className: [
-                    onRowClick ? 'cursor-pointer' : '',
-                    selectedIds.has(product.id) ? 'bg-cg-accent-bg' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' '),
-                },
-                selectable &&
-                  React.createElement(
-                    UI.TableCell,
-                    null,
-                    React.createElement(UI.Checkbox, {
-                      checked: selectedIds.has(product.id),
-                      onCheckedChange: () => toggleSelect(product.id),
-                    })
-                  ),
-                allColumns.map((col) =>
-                  React.createElement(
-                    UI.TableCell,
-                    { key: col.key },
-                    /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-                    col.render ? (col.render(product) as any) : ((product as any)[col.key] ?? '—')
-                    /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-                  )
-                ),
-                extraActions.length > 0 &&
-                  React.createElement(
-                    UI.TableCell,
-                    { className: 'text-right' },
-                    React.createElement(
-                      'div',
-                      { className: 'flex gap-1 justify-end' },
-                      extraActions
-                        .filter((a) => !a.hidden || !a.hidden(product))
-                        .map((action, i) =>
-                          React.createElement(
-                            UI.Button,
-                            {
-                              key: i,
-                              variant: action.variant === 'danger' ? 'destructive' : 'ghost',
-                              size: 'xs',
-                              onClick: (e: { stopPropagation: () => void }) => {
-                                e.stopPropagation();
-                                action.onClick(product);
-                              },
-                            },
-                            action.label
-                          )
-                        )
-                    )
-                  )
-              )
-            )
-          )
-        ),
+    // Cast necesario: ColumnDef.render retorna `unknown`, DataTable espera `ReactNode`
+    return [...base, ...extraColumns] as Array<{
+      key: string;
+      header: string;
+      sortable?: boolean;
+      render?: (item: Product) => React.ReactNode;
+    }>;
+  }, [customColumns, extraColumns]);
 
-    // Pagination
-    pagination.total > pagination.pageSize &&
+  const dtActions = useMemo(() => {
+    if (extraActions.length === 0) return undefined;
+    return extraActions.map((a) => ({
+      label: a.label,
+      onClick: a.onClick,
+      variant: a.variant as 'ghost' | 'destructive' | undefined,
+      hidden: a.hidden,
+    }));
+  }, [extraActions]);
+
+  const mobileRender = useCallback(
+    (product: Product) =>
       React.createElement(
         'div',
-        { className: 'flex items-center justify-between text-sm text-cg-text-muted' },
-        React.createElement('span', null, `Página ${pagination.page}`),
-        React.createElement(
-          UI.Pagination,
-          null,
+        { className: 'flex flex-col gap-1' },
+        // Nombre
+        React.createElement('span', { className: 'font-medium text-sm' }, product.name),
+        // SKU
+        product.sku &&
           React.createElement(
-            UI.PaginationContent,
-            null,
-            React.createElement(UI.PaginationPrevious, {
-              onClick: () => pagination.setPage(Math.max(1, pagination.page - 1)),
-              className: pagination.page <= 1 ? 'pointer-events-none opacity-40' : '',
-            }),
-            React.createElement(UI.PaginationNext, {
-              onClick: () => pagination.setPage(pagination.page + 1),
-              className: data.length < pagination.pageSize ? 'pointer-events-none opacity-40' : '',
-            })
+            'div',
+            { className: 'text-xs', style: { color: 'var(--cg-text-muted)' } },
+            `SKU: ${product.sku}`
+          ),
+        // Precio · Stock
+        React.createElement(
+          'div',
+          { className: 'flex items-center gap-2 mt-1' },
+          React.createElement(
+            'span',
+            { className: 'text-xs', style: { color: 'var(--cg-text-muted)' } },
+            product.sale_price ? `$${Number(product.sale_price).toFixed(2)}` : 'Sin precio'
+          ),
+          React.createElement(StockBadge, {
+            stock: product.stock_current,
+            minimum: product.stock_minimum,
+          })
+        ),
+        // Estado badge
+        React.createElement(
+          'div',
+          { className: 'mt-1' },
+          React.createElement(
+            UI.Badge,
+            { variant: product.is_active ? 'success' : 'secondary', size: 'sm' },
+            product.is_active ? 'Activo' : 'Inactivo'
           )
         )
-      )
+      ),
+    []
   );
+
+  return React.createElement(UI.DataTable, {
+    data,
+    rowKey: (product: Product) => product.id,
+    loading,
+    error: error ?? undefined,
+    onRetry: () => void refetch(),
+    columns: dtColumns,
+    searchPlaceholder: 'Buscar productos...',
+    searchValue,
+    onSearchChange: handleSearch,
+    sortKey: sortKey || null,
+    sortDirection: sortDir,
+    onSortChange: handleSort,
+    selectable,
+    pagination: {
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+      total: pagination.total,
+    },
+    onPageChange: pagination.setPage,
+    actions: dtActions,
+    onRowClick,
+    emptyState: {
+      title: emptyMessage,
+      filteredTitle: emptyMessage,
+      filteredDescription: 'Prueba con otros términos o ajusta los filtros.',
+    },
+    mobileRender,
+  });
 }


### PR DESCRIPTION
## Summary
- Migración de ProductsTable a DataTable con `mobileRender` para vista de cards en móvil (#20)
- Íconos en los headers de secciones del formulario (#19)

## PRs incluidos
- #19 — feat: add icons to form section headers
- #20 — refactor: migrate ProductsTable to DataTable with mobileRender

## Test plan
- [ ] Verificar tabla de productos en desktop (misma funcionalidad)
- [ ] Verificar vista de cards en móvil
- [ ] Verificar íconos en secciones del formulario
- [ ] Build sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)