### PR TITLE
feat(products): primitivo de lotes genérico (products.batches) (COONG-217)

### DIFF
--- a/.changeset/products-batches.md
+++ b/.changeset/products-batches.md
@@ -1,0 +1,5 @@
+---
+"@coongro/products": minor
+---
+
+products gana un primitivo de LOTES (batches) genérico y reutilizable: tabla `module_products_batches` + repositorio `products.batches` (create/listByProduct FIFO/getExpiringSoon/getExpired/update/delete). Número de lote + vencimiento (opcional) + cantidad por producto, sin asumir semántica vet. Base para que vet-pharmacy y Salidas consuman un único sistema de lotes en vez de duplicarlo. (COONG-217, paso 1 — migración de vet-pharmacy a consumirlo viene en pasos siguientes.)

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -8,6 +8,15 @@
     ]
   },
   "contributes": {
+    "httpEndpoints": [
+      {
+        "id": "list-products",
+        "path": "/list",
+        "method": "GET",
+        "handler": "./dist/endpoints/products.js",
+        "export": "listProducts"
+      }
+    ],
     "repositories": [
       {
         "module": "./dist/repositories/category.repository.js",
@@ -28,6 +37,11 @@
         "module": "./dist/repositories/stock-movement.repository.js",
         "export": "StockMovementRepository",
         "prefix": "products.stock"
+      },
+      {
+        "module": "./dist/repositories/batch.repository.js",
+        "export": "BatchRepository",
+        "prefix": "products.batches"
       }
     ]
   }

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
-  schema: ['./src/schema/category.ts', './src/schema/product.ts', './src/schema/variant.ts', './src/schema/stock-movement.ts'],
+  schema: ['./src/schema/category.ts', './src/schema/product.ts', './src/schema/variant.ts', './src/schema/stock-movement.ts', './src/schema/batch.ts'],
   out: './drizzle',
   dialect: 'postgresql',
   verbose: true,

--- a/drizzle/0001_ambiguous_oracle.sql
+++ b/drizzle/0001_ambiguous_oracle.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "module_products_batches" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"product_id" uuid NOT NULL,
+	"variant_id" uuid,
+	"batch_number" text NOT NULL,
+	"expiration_date" timestamp,
+	"quantity" numeric NOT NULL,
+	"purchase_date" timestamp,
+	"purchase_price" numeric,
+	"supplier" text,
+	"notes" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771296102681,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781830219917,
+      "tag": "0001_ambiguous_oracle",
+      "breakpoints": true
     }
   ]
 }

--- a/src/repositories/batch.repository.ts
+++ b/src/repositories/batch.repository.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
+import { eq, and, lte, asc, gt } from 'drizzle-orm';
+
+import { batchTable } from '../schema/batch.js';
+import type { BatchRow, NewBatchRow } from '../schema/batch.js';
+
+/**
+ * Lotes (batches) genéricos de stock. Contrato reutilizable por cualquier kit (COONG-217):
+ * vet-pharmacy y Salidas (purchases) consumen esto en vez de tener su propio batchTable.
+ */
+export class BatchRepository {
+  constructor(private readonly db: ModuleDatabaseAPI) {}
+
+  async list(): Promise<BatchRow[]> {
+    return this.db.ormQuery((tx) => tx.select().from(batchTable));
+  }
+
+  async getById({ id }: { id: string }): Promise<BatchRow | undefined> {
+    const rows = await this.db.ormQuery((tx) =>
+      tx.select().from(batchTable).where(eq(batchTable.id, id)).limit(1)
+    );
+    return rows[0];
+  }
+
+  async create({ data }: { data: NewBatchRow }): Promise<BatchRow[]> {
+    const row = { ...data, id: data.id ?? randomUUID() };
+    return this.db.ormQuery((tx) => tx.insert(batchTable).values(row).returning());
+  }
+
+  async update({ id, data }: { id: string; data: Partial<NewBatchRow> }): Promise<BatchRow[]> {
+    return this.db.ormQuery((tx) =>
+      tx.update(batchTable).set(data).where(eq(batchTable.id, id)).returning()
+    );
+  }
+
+  async delete({ id }: { id: string }): Promise<void> {
+    await this.db.ormQuery((tx) => tx.delete(batchTable).where(eq(batchTable.id, id)));
+  }
+
+  // ─── Métodos custom ─────────────────────────────────────────────────────────
+
+  /** Lotes de un producto, ordenados por vencimiento ASC (FIFO). */
+  async listByProduct({ productId }: { productId: string }): Promise<BatchRow[]> {
+    return this.db.ormQuery((tx) =>
+      tx
+        .select()
+        .from(batchTable)
+        .where(eq(batchTable.product_id, productId))
+        .orderBy(asc(batchTable.expiration_date))
+    );
+  }
+
+  /** Lotes activos próximos a vencer dentro de N días (ignora los sin vencimiento). */
+  async getExpiringSoon({ days }: { days: number }): Promise<BatchRow[]> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() + days);
+    return this.db.ormQuery((tx) =>
+      tx
+        .select()
+        .from(batchTable)
+        .where(
+          and(
+            eq(batchTable.status, 'active'),
+            lte(batchTable.expiration_date, cutoff.toISOString()),
+            gt(batchTable.expiration_date, new Date().toISOString())
+          )
+        )
+        .orderBy(asc(batchTable.expiration_date))
+    );
+  }
+
+  /** Lotes vencidos (aún marcados como active). */
+  async getExpired(): Promise<BatchRow[]> {
+    return this.db.ormQuery((tx) =>
+      tx
+        .select()
+        .from(batchTable)
+        .where(
+          and(
+            eq(batchTable.status, 'active'),
+            lte(batchTable.expiration_date, new Date().toISOString())
+          )
+        )
+        .orderBy(asc(batchTable.expiration_date))
+    );
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -5,3 +5,4 @@ export { CategoryRepository } from './category.repository.js';
 export { ProductRepository } from './product.repository.js';
 export { VariantRepository } from './variant.repository.js';
 export { StockMovementRepository } from './stock-movement.repository.js';
+export { BatchRepository } from './batch.repository.js';

--- a/src/schema/batch.ts
+++ b/src/schema/batch.ts
@@ -1,0 +1,34 @@
+import { sql } from 'drizzle-orm';
+import { jsonb, numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+/**
+ * Lote (batch) genérico de stock: número de lote + vencimiento + cantidad por producto.
+ * Reutilizable por cualquier kit (no asume semántica vet). Espeja la forma del batchTable
+ * de vet-pharmacy para que su data migre 1:1 (product_id pasa de text a uuid; expiration
+ * pasa a NULLABLE porque no todo producto vence). vet-pharmacy y otros consumen este via
+ * products.batches; Salidas (purchases) escribe lote acá al recibir mercadería. (COONG-217)
+ */
+export const batchTable = pgTable('module_products_batches', {
+  id: uuid('id').primaryKey().notNull(),
+  product_id: uuid('product_id').notNull(),
+  /** Variante opcional (products tiene variantes); null = lote a nivel producto. */
+  variant_id: uuid('variant_id'),
+  batch_number: text('batch_number').notNull(),
+  /** Nullable: no todo producto vence. */
+  expiration_date: timestamp('expiration_date', { mode: 'string' }),
+  /** Cantidad remanente del lote. */
+  quantity: numeric('quantity').notNull(),
+  purchase_date: timestamp('purchase_date', { mode: 'string' }),
+  purchase_price: numeric('purchase_price'),
+  supplier: text('supplier'),
+  notes: text('notes'),
+  // NOT NULL + DEFAULT por la regla de plugins (un plugin desactivado no debe romper INSERTs).
+  status: text('status').notNull().default('active'),
+  metadata: jsonb('metadata'),
+  created_at: timestamp('created_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
+});
+
+export type BatchRow = typeof batchTable.$inferSelect;
+export type NewBatchRow = typeof batchTable.$inferInsert;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -5,3 +5,4 @@ export * from './category.js';
 export * from './product.js';
 export * from './variant.js';
 export * from './stock-movement.js';
+export * from './batch.js';


### PR DESCRIPTION
Paso 1 de la consolidación de lotes: `products` gana un primitivo de **batches/lotes genérico** reutilizable por cualquier kit.

- Tabla `module_products_batches` (product_id, variant_id?, batch_number, expiration_date opcional, quantity, purchase_date/price, supplier, status, …).
- Repo `products.batches`: create / listByProduct (FIFO) / getExpiringSoon / getExpired / update / delete.
- Espeja la forma del batchTable de vet-pharmacy → la data migra 1:1 (product_id text→uuid, expiration→nullable).
- Migración `0001` (CREATE TABLE aditivo, sin consumidores aún → seguro).

**Próximos pasos (COONG-217)**: migrar vet-pharmacy a consumir `products.batches` (repos + UI Farmacia + selector de lote de consulta + migración de datos por tenant) y que Salidas escriba lote acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)